### PR TITLE
Philippe helped fix our facebook authentication error...in like 2 sec…

### DIFF
--- a/models/user_model.js
+++ b/models/user_model.js
@@ -7,8 +7,8 @@ var mongoose  = require('mongoose')
 var userSchema = new Schema({
   local: {
     name: String
-    ,email: {type: String, required: true, unique: true}
-    ,password: {type: String, required: true}
+    ,email: {type: String}
+    ,password: {type: String}
     },
   facebook: {
     id: String

--- a/routes/user_routes.js
+++ b/routes/user_routes.js
@@ -9,13 +9,7 @@ userRouter.route('/test')
   .get(userController.allUsers)
   .post(userController.createUser)
 
-//Commented out because these routes were causing an error when trying to
-//connect to /login and /signup routes. It looks like the user id was being
-//attached to the end of the url and throwing the error
-// userRouter.route('/:user_id')
-//   .get(userController.showUser)
-//   .put(userController.updateUser)
-//   .delete(userController.deleteUser)
+
 
 userRouter.route('/login')
     .get(function(req,res){
@@ -57,5 +51,11 @@ function isLoggedIn(req, res, next) {
     if(req.isAuthenticated()) return next()
     res.redirect('/')
 }
+
+
+userRouter.route('/:user_id')
+  .get(userController.showUser)
+  .put(userController.updateUser)
+  .delete(userController.deleteUser)
 
 module.exports = userRouter


### PR DESCRIPTION
…onds...literally. We could not authenticate through facebook because our schema included required email field for the local strategy, causing an error to be thrown. Also we moved the /:user_id routes (for update, show and destroy) to the bottom of the routes file, fixing the error thrown when trying to navigate to /login and /signup. This issue will be closed on github
